### PR TITLE
Add Occult Crescent: South Horn zone info

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "unpkg": "dist/eorzea-weather.umd.js",
-  "version": "3.2.0"
+  "version": "3.3.0"
 }

--- a/src/EorzeaWeather.ts
+++ b/src/EorzeaWeather.ts
@@ -126,6 +126,10 @@ export default class EorzeaWeather {
     return zones.ZONE_NORTHERN_THANALAN;
   }
 
+  static get ZONE_OCCULT_CRESCENT_SOUTH_HORN(): string {
+    return zones.ZONE_OCCULT_CRESCENT_SOUTH_HORN;
+  }
+
   static get ZONE_OUTER_LA_NOSCEA(): string {
     return zones.ZONE_OUTER_LA_NOSCEA;
   }

--- a/src/chances.ts
+++ b/src/chances.ts
@@ -1,4 +1,5 @@
 import {
+  WEATHER_ATMOSPHERIC_PHANTASMS,
   WEATHER_BLIZZARDS,
   WEATHER_CLEAR_SKIES,
   WEATHER_CLOUDS,
@@ -8,6 +9,7 @@ import {
   WEATHER_GALES,
   WEATHER_GLOOM,
   WEATHER_HEAT_WAVES,
+  WEATHER_ILLUSORY_DISTURBANCES,
   WEATHER_RAIN,
   WEATHER_SHOWERS,
   WEATHER_SNOW,
@@ -537,6 +539,25 @@ export const northernThanalan = (chance: number): string => {
     return WEATHER_CLOUDS;
   }
   return WEATHER_FOG;
+};
+
+export const occultCrescentSouthHorn = (chance: number): string => {
+  if (chance < 10) {
+    return WEATHER_CLEAR_SKIES;
+  }
+  if (chance < 55) {
+    return WEATHER_FAIR_SKIES;
+  }
+  if (chance < 70) {
+    return WEATHER_CLOUDS;
+  }
+  if (chance < 80) {
+    return WEATHER_RAIN;
+  }
+  if (chance < 95) {
+    return WEATHER_ATMOSPHERIC_PHANTASMS;
+  }
+  return WEATHER_ILLUSORY_DISTURBANCES;
 };
 
 export const outerLaNoscea = (chance: number): string => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,4 +1,5 @@
 export default {
+  'weathers.atmosphericPhantasms': 'Atmospheric Phantasms',
   'weathers.blizzards': 'Blizzards',
   'weathers.clearSkies': 'Clear Skies',
   'weathers.clouds': 'Clouds',
@@ -8,6 +9,7 @@ export default {
   'weathers.gales': 'Gales',
   'weathers.gloom': 'Gloom',
   'weathers.heatWaves': 'Heat Waves',
+  'weathers.illusoryDisturbances': 'Illusory Disturbances',
   'weathers.rain': 'Rain',
   'weathers.showers': 'Showers',
   'weathers.snow': 'Snow',
@@ -48,6 +50,7 @@ export default {
   'zones.outerLaNoscea': 'Outer La Noscea',
   'zones.rhalgrsReach': "Rhalgr's Reach",
   'zones.shirogane': 'Shirogane',
+  'zones.occultCrescentSouthHorn': 'Occult Crescent: South Horn',
   'zones.southShroud': 'South Shroud',
   'zones.southernThanalan': 'Southern Thanalan',
   'zones.theAzimSteppe': 'The Azim Steppe',

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -45,6 +45,7 @@ export default {
   'zones.morDhona': 'モードゥナ',
   'zones.northernThanalan': '北ザナラーン',
   'zones.northShroud': '黒衣森：北部森林',
+  'zones.occultCrescentSouthHorn': 'クレセントアイル：南征編',
   'zones.outerLaNoscea': '外地ラノシア',
   'zones.rhalgrsReach': 'ラールガーズリーチ',
   'zones.shirogane': 'シロガネ',

--- a/src/weathers.ts
+++ b/src/weathers.ts
@@ -1,3 +1,4 @@
+export const WEATHER_ATMOSPHERIC_PHANTASMS = 'atmosphericPhantasms';
 export const WEATHER_BLIZZARDS = 'blizzards';
 export const WEATHER_CLEAR_SKIES = 'clearSkies';
 export const WEATHER_CLOUDS = 'clouds';
@@ -7,6 +8,7 @@ export const WEATHER_FOG = 'fog';
 export const WEATHER_GALES = 'gales';
 export const WEATHER_GLOOM = 'gloom';
 export const WEATHER_HEAT_WAVES = 'heatWaves';
+export const WEATHER_ILLUSORY_DISTURBANCES = 'illusoryDisturbances';
 export const WEATHER_RAIN = 'rain';
 export const WEATHER_SHOWERS = 'showers';
 export const WEATHER_SNOW = 'snow';

--- a/src/zones.ts
+++ b/src/zones.ts
@@ -27,6 +27,7 @@ export const ZONE_MIST = 'mist';
 export const ZONE_MOR_DHONA = 'morDhona';
 export const ZONE_NORTH_SHROUD = 'northShroud';
 export const ZONE_NORTHERN_THANALAN = 'northernThanalan';
+export const ZONE_OCCULT_CRESCENT_SOUTH_HORN = 'occultCrescentSouthHorn';
 export const ZONE_OUTER_LA_NOSCEA = 'outerLaNoscea';
 export const ZONE_RHALGRS_REACH = 'rhalgrsReach';
 export const ZONE_SHIROGANE = 'shirogane';


### PR DESCRIPTION
Adds weather info for Occult Crescent: South Horn, as well as the two new weather conditions (Atmospheric Phantasms and Illusory Disturbances) that occur in the zone.